### PR TITLE
build(drone): upload dist when merging into master

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,8 +1,8 @@
 workspace:
-  base: /vue
-  path: src/github.com/readr-media/news-projects
+  base: /readr-media
+  path: news-projects
 pipeline:
-  start_slack:
+  start-slack:
     image: plugins/slack
     channel: jenkins
     secrets: [slack_webhook]
@@ -14,24 +14,26 @@ pipeline:
     when:
       event: [push]
   
-  get_dev_config:
+  get-dev-config:
     image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
     secrets: [google_credentials]
     commands:
-    - gcloud source repos clone default ../default
-    - cp ../default/news-projects/dev/config.js api/config.js
-    - cp ../default/readr-site/gcskeyfile.json ./gcskeyfile.json
+    - gcloud source repos clone default default
+    - cp ./default/news-projects/dev/config.js api/config.js
+    - cp ./default/readr-site/gcskeyfile.json ./gcskeyfile.json
+    - rm -rf default
     when:
       event: [push]
       branch: dev
   
-  get_production_config:
+  get-production-config:
     image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
     secrets: [google_credentials]
     commands:
-    - gcloud source repos clone default ../default
-    - cp ../default/news-projects/production/config.js api/config.js
-    - cp ../default/readr-site/gcskeyfile.json ./gcskeyfile.json
+    - gcloud source repos clone default default
+    - cp ./default/news-projects/production/config.js api/config.js
+    - cp ./default/readr-site/gcskeyfile.json ./gcskeyfile.json
+    - rm -rf default
     when:
       event: [push]
       branch: master
@@ -50,7 +52,7 @@ pipeline:
   publish:
     image: plugins/gcr
     repo: mirrormedia-1470651750304/${DRONE_REPO_NAME}
-    tag: ${DRONE_COMMIT_AUTHOR}_${DRONE_BUILD_NUMBER}
+    tag: ${DRONE_BRANCH}_${DRONE_COMMIT_AUTHOR}_${DRONE_BUILD_NUMBER}
     environment:
       - DOCKER_LAUNCH_DEBUG=true
     secrets: [google_credentials]
@@ -58,8 +60,21 @@ pipeline:
       event: [push]
       branch: [master, dev]
   
-  deploy_dev:
-    image: nytimes/drone-gke
+  upload:
+    image: plugins/gcs
+    source: dist
+    target: readr-files/distribution/
+    acl: allUsers:READER
+    # cache_control: public, max-age=3600
+    secrets:
+      - source: google_credentials
+        target: token
+    when:
+      event: push
+      branch: master
+
+  deploy-dev:
+    image: nytimes/drone-gke      
     zone: asia-east1-a
     cluster: dev
     namespace: default
@@ -77,7 +92,7 @@ pipeline:
       event: [push]
       branch: dev
  
-  finish_slack:
+  finish-slack:
     image: plugins/slack
     channel: jenkins
     secrets: [slack_webhook]


### PR DESCRIPTION
In this pull request, I inserted a section to upload dist files built by webpack to Google Cloud Storage when merging into `master` branch. I think using this method could avoiding using unstable uploading method with `kubectl cp` when the files amount are too large.

@FalseChord, you might probably need this as a booster if the debug in `kubectl cp` does not go well.