### PR TITLE
ElectionBoard: display verification data horizontally to enlarge photo size

### DIFF
--- a/src/components/ElectionBoard/ElectionBoardVerify.vue
+++ b/src/components/ElectionBoard/ElectionBoardVerify.vue
@@ -562,4 +562,20 @@ theme-color-hidden = #6d5810
     & .image
       width 450px
       margin 0 auto
+
+@media (min-width 1024px)
+  & .eb-verify
+    flex-direction row
+    & .image
+      width 50vw
+      height 100vh
+      position relative
+      top -55px
+      & img
+        object-position center
+        padding 2rem
+    & .form
+      width 50vw
+      padding 0 4rem
+      margin-top 0
 </style>


### PR DESCRIPTION
Please help to verify this PR as I didn't get Redis running in my environment XD

Expected Result:
![Screenshot_2019-12-12 看板追追追——鍵盤辨識徵求中！ - 讀＋READr](https://user-images.githubusercontent.com/271157/70690545-d4234a00-1cf1-11ea-8a0d-478a8ff2da35.png)
