### PR TITLE
Election2020: add color stylus variables and import globally

### DIFF
--- a/build/webpack.base.config.js
+++ b/build/webpack.base.config.js
@@ -113,7 +113,17 @@ module.exports = {
               'vue-style-loader',
               'css-loader',
               'postcss-loader',
-              'stylus-loader'
+              {
+                loader: 'stylus-loader',
+                options: {
+                  // workaround import for Election2020 project,
+                  // variables import by this rule will available in every projects,
+                  // so i call this workaround.
+                  import: [
+                    path.resolve(__dirname, '../src/components/Election2020/styles/color.styl')
+                  ]
+                }
+              }
             ]
           }
         ]

--- a/src/components/Election2020/styles/color.styl
+++ b/src/components/Election2020/styles/color.styl
@@ -1,0 +1,13 @@
+$color-black = rgba(0, 0, 0, 0.88)
+$color-black-light = rgba(0, 0, 0, 0.87)
+$color-black-lighter = rgba(0, 0, 0, 0.66)
+
+$color-blue = #4A92E5
+$color-blue-light = rgba(74, 146, 229, 0.51)
+$color-green = #3FC479
+$color-green-light = rgba(63, 196, 121, 0.5)
+$color-orange = #EB673C
+$color-purple = #AA67E5
+$color-purple-light = rgba(170, 103, 229, 0.5)
+$color-gray = #9B9B9B
+$color-gray-light = rgba(155, 155, 155, 0.51)


### PR DESCRIPTION
You can use these variables in every style section of `.vue` file.
e.g.
```
<style lang="stylus" scoped>
.foo-class
  color $color-blue // this line is equivalent to "color #4A92E5"
</style>
```