### PR TITLE
Election2020: add Square.vue and Legend.vue component

### DIFF
--- a/src/components/Election2020/components/Legend.vue
+++ b/src/components/Election2020/components/Legend.vue
@@ -1,0 +1,66 @@
+<template>
+  <!-- 
+    How to use this component:
+    <Legend
+      :showSquareBorder="true || false"
+      :squareColor="'black'"
+      :text="'foo legend text'"
+    />
+   -->
+  <div class="legend">
+    <Square
+      class="legend__square"
+      :color="squareColor"
+      :showBorder="showSquareBorder"
+    />
+    <span
+      class="legend__text"
+      v-text="text"
+    />
+  </div>
+</template>
+
+<script>
+import Square from './Square.vue'
+
+export default {
+  props: {
+    squareColor: {
+      type: String,
+      default: 'black',
+      validator(value) {
+        return [
+          'black',
+          'white',
+          'blue',
+          'green',
+          'orange',
+          'purple',
+          'gray'
+        ].includes(value)
+      }
+    },
+    showSquareBorder: {
+      type: Boolean,
+      default: false
+    },
+    text: {
+      type: String,
+      default: 'foo legend text'
+    }
+  },
+  components: {
+    Square
+  }
+}
+</script>
+
+<style lang="stylus" scoped>
+.legend
+  display flex
+  align-items center
+  &__text
+    margin 0 0 0 10px
+    font-size 14px
+    color $color-black-lighter
+</style>

--- a/src/components/Election2020/components/Square.vue
+++ b/src/components/Election2020/components/Square.vue
@@ -1,0 +1,65 @@
+<template>
+  <!-- 
+    How to use this component:
+    <Square
+      :showBorder="true || false"
+      :color="'black'"
+    />
+   -->
+  <div
+    :class="[
+      'square',
+      { 'square--with-border': showBorder },
+      `square--${color}`
+    ]"
+  />
+</template>
+
+<script>
+export default {
+  props: {
+    showBorder: {
+      type: Boolean,
+      default: false
+    },
+    color: {
+      type: String,
+      default: 'black',
+      validator(value) {
+        return [
+          'black',
+          'white',
+          'blue',
+          'green',
+          'orange',
+          'purple',
+          'gray'
+        ].includes(value)
+      }
+    }
+  }
+}
+</script>
+
+<style lang="stylus" scoped>
+.square
+  d = 20px
+  width d
+  height d
+  &--with-border
+    border solid 4px rgba(0, 0, 0, 0.3)
+  &--black
+    background-color $color-black
+  &--white
+    background-color #ffffff
+  &--blue
+    background-color $color-blue
+  &--green
+    background-color $color-green
+  &--orange
+    background-color $color-orange
+  &--purple
+    background-color $color-purple
+  &--gray
+    background-color $color-gray
+</style>


### PR DESCRIPTION
Add components for:
* 圖表圖例（Legends）
  * props
    * `showSquareBorder`: `Boolean`， 顯示 square border 與否。
    * `squareColor`: `String`，square 的顏色，只接受特定幾種顏色（見 props validator）
    * `text`: `String`，圖例的文字。
* 方塊元素
  * props
    * `showBorder`: `Boolean`， 顯示 border 與否。
    * `color`: `String`，只接受特定幾種顏色（見 props validator）

For more info: https://paper.dropbox.com/doc/Election2020-Style-Component-Guide--AqpY8eoqMfLS98EcdAmQTrPHAg-dNG6ZCsOn9ncWzz6DjsxZ