### PR TITLE
Election2020: add Counter.vue and SeatTotal.vue component

### DIFF
--- a/src/components/Election2020/Election2020.vue
+++ b/src/components/Election2020/Election2020.vue
@@ -15,6 +15,10 @@
       <h2>立委激戰搶席次</h2>
       <Countdown />
     </section>
+    只是測試用：
+    <SeatTotal
+      :count="79"
+    />
     <lazy-component class="section subscr">
       <SubscriptionWithLogoMsg />
     </lazy-component>
@@ -31,6 +35,7 @@ import Countdown from './components/Countdown.vue'
 import FirebaseRead from './templates/FirebaseRead.vue'
 import FirebaseCreateUpdate from './templates/FirebaseCreateUpdate.vue'
 import Header from './components/Header.vue'
+import SeatTotal from './components/SeatTotal.vue'
 
 const fetchLatestNews = store => store.dispatch('Election2020/FETCH_GOOGLE_SHEET', {
   params: {
@@ -63,7 +68,8 @@ export default {
     FirebaseRead,
     Header,
     LatestNews: () => import('./components/LatestNews.vue'),
-    SubscriptionWithLogoMsg: () => import('src/components/SubscriptionWithLogoMsg.vue')
+    SubscriptionWithLogoMsg: () => import('src/components/SubscriptionWithLogoMsg.vue'),
+    SeatTotal
   },
   beforeMount () {
     this.registerStoreModule(true)

--- a/src/components/Election2020/components/Counter.vue
+++ b/src/components/Election2020/components/Counter.vue
@@ -1,0 +1,44 @@
+<template>
+  <ICountUp
+    class="counter"
+    :startVal="iCountUp.startVal"
+    :endVal="count"
+    :decimals="iCountUp.decimals"
+    :duration="iCountUp.duration"
+    :options="iCountUp.options"
+  />
+</template>
+
+<script>
+import ICountUp from 'vue-countup-v2'
+
+export default {
+  props: {
+    count: {
+      type: Number,
+      default: 0
+    }
+  },
+  components: {
+    ICountUp,
+  },
+  data () {
+    return {
+      iCountUp: {
+        startVal: 0,
+        // endVal: 0,
+        decimals: 0,
+        duration: 1,
+        options: {
+          useEasing: true,
+          useGrouping: true,
+          separator: ',',
+          decimal: '.',
+          prefix: '',
+          suffix: ''
+        }
+      }
+    }
+  }
+}
+</script>

--- a/src/components/Election2020/components/SeatTotal.vue
+++ b/src/components/Election2020/components/SeatTotal.vue
@@ -1,0 +1,35 @@
+<template>
+  <p class="seat-total">
+    共計
+    <Counter
+      class="seat-total__count"
+      :count="count"
+    />
+    席
+  </p>
+</template>
+
+<script>
+import Counter from './Counter.vue'
+
+export default {
+  props: {
+    count: {
+      type: Number,
+      default: 0
+    }
+  },
+  components: {
+    Counter
+  }
+}
+</script>
+
+<style lang="stylus" scoped>
+.seat-total
+  font-size 16px
+  color $color-black-light
+  &__count
+    font-family $font-family-serif
+    font-size 30px
+</style>


### PR DESCRIPTION
Add components for:
* 共計 X 席
  * props
    * `count`: `Number`
* 計數元件
  * 就是個會動的數字。
  * props
    * `count`: `Number`

For more info: https://paper.dropbox.com/doc/Election2020-Style-Component-Guide--AqpY8eoqMfLS98EcdAmQTrPHAg-dNG6ZCsOn9ncWzz6DjsxZ