### PR TITLE
Election2020: refactor timer

### DIFF
--- a/src/components/Election2020/Election2020.vue
+++ b/src/components/Election2020/Election2020.vue
@@ -58,7 +58,7 @@
 <script>
 import storeModule from 'src/store/modules/Election2020'
 import { createNamespacedHelpers } from 'vuex'
-// const { mapState, mapMutations } = createNamespacedHelpers('Election2020')
+const { mapActions } = createNamespacedHelpers('Election2020')
 import Countdown from './components/Countdown.vue'
 import FirebaseRead from './templates/FirebaseRead.vue'
 import FirebaseCreateUpdate from './templates/FirebaseCreateUpdate.vue'
@@ -123,10 +123,16 @@ export default {
   beforeMount () {
     this.registerStoreModule(true)
   },
+  mounted() {
+    this.INIT_TIMER()
+  },
   destroyed() {
     this.$store.unregisterModule('Election2020')
   },
   methods: {
+    ...mapActions({
+      INIT_TIMER: 'timer/INIT_TIMER'
+    }),
     registerStoreModule (shouldPreserveState = false) {
       this.$store.registerModule('Election2020', storeModule, { preserveState: shouldPreserveState })
     },

--- a/src/components/Election2020/components/Countdown.vue
+++ b/src/components/Election2020/components/Countdown.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="countdown">
-    <template v-if="remainingTime >= 0">
+    <template v-if="!isElectionBoxOpeningStart">
       <span>離開票還有 </span>
       <span v-if="remainingTimeInfo.days > 0" v-text="`${remainingTimeInfo.days} 日 `" />
       <span v-if="remainingTimeInfo.hours > 0" v-text="`${remainingTimeInfo.hours} 時 `" />
@@ -17,7 +17,10 @@
 
 import moment from 'moment'
 
-const COUNTING_START_TIME = '2020-01-11T16:00:00+0800' // ISO 8601
+import { createNamespacedHelpers } from 'vuex'
+const { mapGetters } = createNamespacedHelpers('Election2020')
+
+import { COUNTING_START_TIME } from '../../../store/modules/Election2020/modules/timer.js'
 
 export default {
   name: 'Countdown',
@@ -27,40 +30,12 @@ export default {
       default: () => new Date(COUNTING_START_TIME)
     }
   },
-  data () {
-    return {
-      currentTime: new Date().toISOString(),
-      timer: undefined
-    }
-  },
   computed: {
-    remainingTime () {
-      return new Date(COUNTING_START_TIME) - new Date(this.currentTime)
-    },
-    remainingTimeInfo () {
-      const end = moment(COUNTING_START_TIME)
-      const now = moment(this.currentTime)
-      const diff = moment.duration(end.diff(now))
-      return {
-        days: diff.days(),
-        hours: diff.hours(),
-        minutes: diff.minutes(),
-        seconds: diff.seconds()
-      }
-    }
-  },
-  watch: {
-    remainingTime (value) {
-      value < 0 && clearInterval(this.timer)
-    }
-  },
-  mounted () {
-    if (!this.timer) {
-      this.timer = setInterval(() => this.currentTime = new Date().toISOString(), 1000)
-    }
-  },
-  destroyed () {
-    clearInterval(this.timer)
+    ...mapGetters({
+      remainingTime: 'timer/remainingTime',
+      remainingTimeInfo: 'timer/remainingTimeInfo',
+      isElectionBoxOpeningStart: 'timer/isElectionBoxOpeningStart'
+    })
   },
   methods: {
     moment

--- a/src/store/modules/Election2020/index.js
+++ b/src/store/modules/Election2020/index.js
@@ -1,11 +1,13 @@
 import Vue from 'vue'
 import { get } from 'lodash'
 import { getSheet } from 'src/api'
+import { timerModule as timer } from './modules/timer'
 
 export default {
   namespaced: true,
-  // modules: {
-  // },
+  modules: {
+    timer
+  },
   state: () => ({
     spreadsheet: {
       latestNews: []

--- a/src/store/modules/Election2020/modules/timer.js
+++ b/src/store/modules/Election2020/modules/timer.js
@@ -18,12 +18,14 @@ export const timerModule = {
   actions: {
     INIT_TIMER({ state, commit, getters }) {
       const isTimerExist = state.timer !== undefined
-      const isElectionBoxOpeningStart = getters.isElectionBoxOpeningStart
-      if (isTimerExist || isElectionBoxOpeningStart) {
+      if (isTimerExist || getters.isElectionBoxOpeningStart) {
         return
       }
 
       const timer = setInterval(() => {
+        if (getters.isElectionBoxOpeningStart) {
+          clearInterval(state.timer)
+        }
         commit('SET_CURRENT_TIME', new Date().toISOString())
       }, 1000)
       commit('SET_TIMER', timer)

--- a/src/store/modules/Election2020/modules/timer.js
+++ b/src/store/modules/Election2020/modules/timer.js
@@ -1,0 +1,51 @@
+import moment from 'moment'
+export const COUNTING_START_TIME = '2020-01-11T16:00:00+0800' // ISO 8601
+
+export const timerModule = {
+  namespaced: true,
+  state: () => ({
+    currentTime: new Date().toISOString(),
+    timer: undefined
+  }),
+  mutations: {
+    SET_CURRENT_TIME(state, time) {
+      state.currentTime = time
+    },
+    SET_TIMER(state, timer) {
+      state.timer = timer
+    }
+  },
+  actions: {
+    INIT_TIMER({ state, commit, getters }) {
+      const isTimerExist = state.timer !== undefined
+      const isElectionBoxOpeningStart = getters.isElectionBoxOpeningStart
+      if (isTimerExist || isElectionBoxOpeningStart) {
+        return
+      }
+
+      const timer = setInterval(() => {
+        commit('SET_CURRENT_TIME', new Date().toISOString())
+      }, 1000)
+      commit('SET_TIMER', timer)
+    }
+  },
+  getters: {
+    remainingTime(state) {
+      return new Date(COUNTING_START_TIME) - new Date(state.currentTime)
+    },
+    remainingTimeInfo(state) {
+      const end = moment(COUNTING_START_TIME)
+      const now = moment(state.currentTime)
+      const diff = moment.duration(end.diff(now))
+      return {
+        days: diff.days(),
+        hours: diff.hours(),
+        minutes: diff.minutes(),
+        seconds: diff.seconds()
+      }
+    },
+    isElectionBoxOpeningStart(state, getters) {
+      return getters.remainingTime < 0
+    }
+  }
+}


### PR DESCRIPTION
* 因為專題中有許多地方需要得知「目前是否已經開票」，所以我把原本在 `Countdown.vue`  中跟 timer 有關的邏輯抽出來放在 store 中，以便供其他 components 判斷這件事情。
* 新增的 `timer.js` export 兩個變數：
  1. `COUNTING_ START_TIME`：開票時間常數。
  2. `timerModule`：vuex store module。
* `timerModule` 中的 `getters` 含有除了原本 `Countdown.vue` 中會使用到的 `remainingTime`, `remainingTimeInfo` 外，另新增 `isElectionBoxOpeningStart` 來辨別「目前是否已經開票」。