### PR TITLE
Election2020: add tooltip component

### DIFF
--- a/src/components/Election2020/components/PresidentCountChart.vue
+++ b/src/components/Election2020/components/PresidentCountChart.vue
@@ -12,6 +12,10 @@
           key="pfpBar"
           class="bar pfp"
           :style="{ width: `${formatRatio(testData['1'].R)}%` }"
+          @mouseenter="handleTooltip(true, $event)"
+          @mouseleave="handleTooltip(false)"
+          @click="handleTooltip(true, $event)"
+          @close="handleTooltip(false)"
         />
         <div
           key="kmtBar"
@@ -20,6 +24,10 @@
             width: `${formatRatio(testData['2'].R)}%`,
             left: `${formatRatio(testData['1'].R)}%`
           }"
+          @mouseenter="handleTooltip(true, $event)"
+          @mouseleave="handleTooltip(false)"
+          @click="handleTooltip(true, $event)"
+          @close="handleTooltip(false)"
         />
         <div
           key="dppBar"
@@ -28,6 +36,10 @@
             width: `${formatRatio(testData['3'].R)}%`,
             left: `${formatRatio(testData['1'].R) + formatRatio(testData['2'].R)}%`
           }"
+          @mouseenter="handleTooltip(true, $event)"
+          @mouseleave="handleTooltip(false)"
+          @click="handleTooltip(true, $event)"
+          @close="handleTooltip(false)"
         />
       </template>
     </transition-group>
@@ -36,35 +48,55 @@
       <div class="label kmt">國民黨</div>
       <div class="label dpp">民進黨</div>
     </div>
+    <Tooltip :showTooltip="showTooltip" :x="tooltipX" :y="tooltipY">
+      <InfoDetailed
+        title="宋楚瑜、余湘"
+        subtitle="親民黨"
+        :tableData="[
+          { name: '得票數', tks: 429148 },
+          { name: '得票率', R: 0.11123213 }
+        ]"
+      />
+    </Tooltip>
   </div>
 </template>
 <script>
 import { formatRatio } from '../utility/common'
+import { throttle } from 'lodash'
+import InfoDetailed from './InfoDetailed.vue'
+import Tooltip from './Tooltip.vue'
 
 export default {
   name: 'PresidentCountChart',
+  components: {
+    InfoDetailed,
+    Tooltip
+  },
   data () {
     return {
+      showTooltip: false,
+      tooltipX: 0,
+      tooltipY: 0,
       testData: {
         '1': {
-          R: 0,
-          tks: 0,
-          // R: 0.2587852392781253,
-          // tks: 10808489,
+          // R: 0,
+          // tks: 0,
+          R: 0.2587852392781253,
+          tks: 10808489,
           isElected: false
         },
         '2': {
-          R: 0,
-          tks: 0,
-          // R: 0.37826896118277314,
-          // tks: 15798876,
+          // R: 0,
+          // tks: 0,
+          R: 0.37826896118277314,
+          tks: 15798876,
           isElected: false
         },
         '3': {
-          R: 0,
-          tks: 0,
-          // R: 0.36294579953910155,
-          // tks: 15158885,
+          // R: 0,
+          // tks: 0,
+          R: 0.36294579953910155,
+          tks: 15158885,
           isElected: false
         }
       }
@@ -76,7 +108,14 @@ export default {
     }
   },
   methods: {
-    formatRatio
+    formatRatio,
+    handleTooltip (value, event) {
+      this.showTooltip = value
+      if (event) {
+        this.tooltipX = event.clientX
+        this.tooltipY = event.clientY
+      }
+    }
   }
 }
 </script>

--- a/src/components/Election2020/components/Tooltip.vue
+++ b/src/components/Election2020/components/Tooltip.vue
@@ -1,0 +1,100 @@
+<template>
+  <div
+    v-show="showTooltip"
+    ref="tooltip"
+    :style="{ top: `${y + offset}px`, left: `${x + offset}px` }"
+    class="tooltip"
+    v-click-outside="handleClickOutside"
+  >
+    <slot />
+  </div>
+</template>
+<script>
+export default {
+  name: 'Tooltip',
+  props: {
+    showTooltip: {
+      type: Boolean,
+      default: false
+    },
+    x: {
+      type: Number,
+      required: true
+    },
+    y: {
+      type: Number,
+      required: true
+    },
+    offset: {
+      type: Number,
+      default: 20
+    }
+  },
+  directives: {
+    'click-outside': {
+      bind (el, binding, vnode) {
+        el.clickOutsideEvent = function (event) {
+          if (!(el == event.target || el.contains(event.target))) {
+            vnode.context[binding.expression](event)
+          }
+        }
+        document.body.addEventListener('click', el.clickOutsideEvent)
+      },
+      unbind (el) {
+        document.body.removeEventListener('click', el.clickOutsideEvent)
+      }
+    }
+  },
+  watch: {
+    showTooltip (value) {
+      if (value) {
+        const viewportWidth = window.innerWidth || document.documentElement.clientWidth
+        const viewportHeight = window.innerHeight || document.documentElement.clientHeight
+        this.$nextTick(() => {
+          // const rect = this.$refs.tooltip.getBoundingClientRect()
+          const isOutWidth = this.x + this.offset + 300 > viewportWidth // rect.right > viewportWidth
+          const isOutHeight = this.y + this.offset + this.$refs.tooltip.offsetHeight > viewportHeight // rect.bottom > viewportHeight
+          
+          if (isOutWidth && isOutHeight) {
+            this.$refs.tooltip.classList.add('fix-both')
+          } else if (isOutWidth) {
+            this.$refs.tooltip.classList.add('fix-horiz')
+          } else if (isOutHeight) {
+            this.$refs.tooltip.classList.add('fix-vert')
+          }
+        })
+      } else {
+        this.$refs.tooltip.classList.remove('fix-both')
+        this.$refs.tooltip.classList.remove('fix-horiz')
+        this.$refs.tooltip.classList.remove('fix-vert')
+      }
+    }
+  },
+  methods: {
+    handleClickOutside () {
+      if (this.showTooltip) {
+        this.$emit('close')
+      }
+    }
+  }
+}
+</script>
+<style lang="stylus" scoped>
+.tooltip
+  position fixed
+  padding 20px 15px
+  background-color #fff
+  border 1px solid rgba(0, 0, 0, .3)
+  z-index 500
+  &.fix-horiz
+    transform translateX(-100%)
+  &.fix-vert
+    transform translateY(-100%)
+  &.fix-both
+    transform translate(-100%, -100%)
+  
+@media (min-width: 768px)
+  .tooltip
+    min-width 300px
+    
+</style>


### PR DESCRIPTION
`Tooltip.vue`

props:
`showTooltip`: 控制是否顯示 tooltip
`x`: 控制 tooltip 在頁面水平的位置
`y`: 控制 tooltip 在頁面垂直的位置
`offset`: 控制 tooltip 依照 x, y 值向右和向下的偏移距離，預設為 20 (px)


tooltip 中用 `slot` 來接受要在裡面顯示的內容，然後必須在要使用 tooltip 的元素上，加上 `mouseenter`, `mouseleave`, `click`, `close` 事件來控制，可以參考 `PresidentCountChart.vue` 的用法