### PR TITLE
ci: use latest drone-gke to update dev cluster

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,7 +59,7 @@ pipeline:
       branch: [master, dev]
   
   deploy_dev:
-    image: nytimes/drone-gke:develop
+    image: nytimes/drone-gke
     zone: asia-east1-a
     cluster: dev
     namespace: default


### PR DESCRIPTION
`drone-gke:develop` was removed from DockerHub. We've lost our version in docker-builder so we could not use this docker anymore.

The tag of `develop` was removed and from now on we should try on the latest version.